### PR TITLE
Update to`0.0.2`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 
 [project]
 name = "pyticktick"
-version = "0.0.1"
+version = "0.0.2"
 description = "The modern library to interact with the TickTick API."
 authors = [{ name = "Seb Pretzer", email = "quick.creek3304@fastmail.com" }]
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -1203,7 +1203,7 @@ wheels = [
 
 [[package]]
 name = "pyticktick"
-version = "0.0.1"
+version = "0.0.2"
 source = { editable = "." }
 dependencies = [
     { name = "click", version = "8.1.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },


### PR DESCRIPTION
Because `test.pypi.org` already had version `0.0.1` published before it was deleted, it caused [the following issue](https://github.com/sebpretzer/pyticktick/actions/runs/15261398688/job/42919793409) in the build:

```
uv publish --index testpypi
Publishing 2 files https://test.pypi.org/legacy/
Uploading pyticktick-0.0.1-py3-none-any.whl (51.9KiB)
error: Failed to publish `dist/pyticktick-0.0.1-py3-none-any.whl` to https://test.pypi.org/legacy/
  Caused by: Upload failed with status code 400 Bad Request. Server says: 400 This filename has already been used, use a different version. See https://test.pypi.org/help/#file-name-reuse for more information.
make: *** [Makefile:28: publish-dev] Error 2
```