### PR TITLE
Shorten Env Prefix

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -123,12 +123,12 @@ jobs:
         run: make test-integration
         env:
           COVERAGE_FILE: coverage/.coverage.integration-3.13
-          TICKTICK_API_V1_CLIENT_ID: ${{ secrets.TICKTICK_API_V1_CLIENT_ID }}
-          TICKTICK_API_V1_CLIENT_SECRET: ${{ secrets.TICKTICK_API_V1_CLIENT_SECRET }}
-          TICKTICK_API_V1_TOKEN_VALUE: ${{ secrets.TICKTICK_API_V1_TOKEN_VALUE }}
-          TICKTICK_API_V1_TOKEN_EXPIRATION: ${{ secrets.TICKTICK_API_V1_TOKEN_EXPIRATION }}
-          TICKTICK_API_V2_USERNAME: ${{ secrets.TICKTICK_API_V2_USERNAME }}
-          TICKTICK_API_V2_PASSWORD: ${{ secrets.TICKTICK_API_V2_PASSWORD }}
+          PYTICKTICK_V1_CLIENT_ID: ${{ secrets.PYTICKTICK_V1_CLIENT_ID }}
+          PYTICKTICK_V1_CLIENT_SECRET: ${{ secrets.PYTICKTICK_V1_CLIENT_SECRET }}
+          PYTICKTICK_V1_TOKEN_VALUE: ${{ secrets.PYTICKTICK_V1_TOKEN_VALUE }}
+          PYTICKTICK_V1_TOKEN_EXPIRATION: ${{ secrets.PYTICKTICK_V1_TOKEN_EXPIRATION }}
+          PYTICKTICK_V2_USERNAME: ${{ secrets.PYTICKTICK_V2_USERNAME }}
+          PYTICKTICK_V2_PASSWORD: ${{ secrets.PYTICKTICK_V2_PASSWORD }}
       - name: Store coverage files
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:

--- a/docs/guides/cookbook/settings/authenticate_client_via_dotenv.md
+++ b/docs/guides/cookbook/settings/authenticate_client_via_dotenv.md
@@ -17,10 +17,10 @@ For our V2 authentication requirements, assume our username is `computer_wiz_02@
     First, make a Dotenv (`.env`) file in your project directory with the following content:
 
     ```env title=".env"
-    TICKTICK_API_V1_CLIENT_ID=7p3Hw9YMqnfxaIvKc4
-    TICKTICK_API_V1_CLIENT_SECRET=Qxm^^3h(7ZK994U8M%/g!YFo2VEPs*k!
-    TICKTICK_API_V1_TOKEN_VALUE=a5b2c3a7-9385-47e4-80b8-a445f842e403
-    TICKTICK_API_V1_TOKEN_EXPIRATION=1781373801
+    PYTICKTICK_V1_CLIENT_ID=7p3Hw9YMqnfxaIvKc4
+    PYTICKTICK_V1_CLIENT_SECRET=Qxm^^3h(7ZK994U8M%/g!YFo2VEPs*k!
+    PYTICKTICK_V1_TOKEN_VALUE=a5b2c3a7-9385-47e4-80b8-a445f842e403
+    PYTICKTICK_V1_TOKEN_EXPIRATION=1781373801
     ```
 
     Then, you can create the client like this:
@@ -41,8 +41,8 @@ For our V2 authentication requirements, assume our username is `computer_wiz_02@
     First, make a Dotenv (`.env`) file in your project directory with the following content:
 
     ```env title=".env"
-    TICKTICK_API_V2_USERNAME=computer_wiz_02@python.org
-    TICKTICK_API_V2_PASSWORD=password123
+    PYTICKTICK_V2_USERNAME=computer_wiz_02@python.org
+    PYTICKTICK_V2_PASSWORD=password123
     ```
 
     Then, you can create the client like this:
@@ -63,12 +63,12 @@ For our V2 authentication requirements, assume our username is `computer_wiz_02@
     First, make a Dotenv (`.env`) file in your project directory with the following content:
 
     ```env title=".env"
-    TICKTICK_API_V1_CLIENT_ID=7p3Hw9YMqnfxaIvKc4
-    TICKTICK_API_V1_CLIENT_SECRET=Qxm^^3h(7ZK994U8M%/g!YFo2VEPs*k!
-    TICKTICK_API_V1_TOKEN_VALUE=a5b2c3a7-9385-47e4-80b8-a445f842e403
-    TICKTICK_API_V1_TOKEN_EXPIRATION=1781373801
-    TICKTICK_API_V2_USERNAME=computer_wiz_02@python.org
-    TICKTICK_API_V2_PASSWORD=password123
+    PYTICKTICK_V1_CLIENT_ID=7p3Hw9YMqnfxaIvKc4
+    PYTICKTICK_V1_CLIENT_SECRET=Qxm^^3h(7ZK994U8M%/g!YFo2VEPs*k!
+    PYTICKTICK_V1_TOKEN_VALUE=a5b2c3a7-9385-47e4-80b8-a445f842e403
+    PYTICKTICK_V1_TOKEN_EXPIRATION=1781373801
+    PYTICKTICK_V2_USERNAME=computer_wiz_02@python.org
+    PYTICKTICK_V2_PASSWORD=password123
     ```
 
     Then, you can create the client like this:

--- a/docs/guides/cookbook/settings/authenticate_client_via_env_vars.md
+++ b/docs/guides/cookbook/settings/authenticate_client_via_env_vars.md
@@ -17,10 +17,10 @@ For our V2 authentication requirements, assume our username is `computer_wiz_02@
     First, export the following environment variables:
 
     ```bash
-    export TICKTICK_API_V1_CLIENT_ID=7p3Hw9YMqnfxaIvKc4
-    export TICKTICK_API_V1_CLIENT_SECRET=Qxm^^3h(7ZK994U8M%/g!YFo2VEPs*k!
-    export TICKTICK_API_V1_TOKEN_VALUE=a5b2c3a7-9385-47e4-80b8-a445f842e403
-    export TICKTICK_API_V1_TOKEN_EXPIRATION=1781373801
+    export PYTICKTICK_V1_CLIENT_ID=7p3Hw9YMqnfxaIvKc4
+    export PYTICKTICK_V1_CLIENT_SECRET=Qxm^^3h(7ZK994U8M%/g!YFo2VEPs*k!
+    export PYTICKTICK_V1_TOKEN_VALUE=a5b2c3a7-9385-47e4-80b8-a445f842e403
+    export PYTICKTICK_V1_TOKEN_EXPIRATION=1781373801
     ```
 
     Then, you can create the client like this:
@@ -41,8 +41,8 @@ For our V2 authentication requirements, assume our username is `computer_wiz_02@
     First, export the following environment variables:
 
     ```bash
-    export TICKTICK_API_V2_USERNAME=computer_wiz_02@python.org
-    export TICKTICK_API_V2_PASSWORD=password123
+    export PYTICKTICK_V2_USERNAME=computer_wiz_02@python.org
+    export PYTICKTICK_V2_PASSWORD=password123
     ```
 
     Then, you can create the client like this:
@@ -63,12 +63,12 @@ For our V2 authentication requirements, assume our username is `computer_wiz_02@
     First, export the following environment variables:
 
     ```bash
-    export TICKTICK_API_V1_CLIENT_ID=7p3Hw9YMqnfxaIvKc4
-    export TICKTICK_API_V1_CLIENT_SECRET=Qxm^^3h(7ZK994U8M%/g!YFo2VEPs*k!
-    export TICKTICK_API_V1_TOKEN_VALUE=a5b2c3a7-9385-47e4-80b8-a445f842e403
-    export TICKTICK_API_V1_TOKEN_EXPIRATION=1781373801
-    export TICKTICK_API_V2_USERNAME=computer_wiz_02@python.org
-    export TICKTICK_API_V2_PASSWORD=password123
+    export PYTICKTICK_V1_CLIENT_ID=7p3Hw9YMqnfxaIvKc4
+    export PYTICKTICK_V1_CLIENT_SECRET=Qxm^^3h(7ZK994U8M%/g!YFo2VEPs*k!
+    export PYTICKTICK_V1_TOKEN_VALUE=a5b2c3a7-9385-47e4-80b8-a445f842e403
+    export PYTICKTICK_V1_TOKEN_EXPIRATION=1781373801
+    export PYTICKTICK_V2_USERNAME=computer_wiz_02@python.org
+    export PYTICKTICK_V2_PASSWORD=password123
     ```
 
     Then, you can create the client like this:

--- a/docs/guides/development/running_tests_locally.md
+++ b/docs/guides/development/running_tests_locally.md
@@ -25,12 +25,12 @@ open htmlcov/index.html
 Before running the integration tests, you need to set up your environment variables. You can do this by creating a `.env` file in the root of the repo and adding the following environment variables:
 
 ```bash title=".env"
-TICKTICK_API_V1_CLIENT_ID="YOUR_CLIENT_ID"
-TICKTICK_API_V1_CLIENT_SECRET="YOUR_CLIENT_SECRET"
-TICKTICK_API_V1_TOKEN_VALUE="YOUR_TOKEN_UUID"
-TICKTICK_API_V1_TOKEN_EXPIRATION=1111111111
-TICKTICK_API_V2_USERNAME="YOUR_USERNAME"
-TICKTICK_API_V2_PASSWORD="YOUR_PASSWORD"
+PYTICKTICK_V1_CLIENT_ID="YOUR_CLIENT_ID"
+PYTICKTICK_V1_CLIENT_SECRET="YOUR_CLIENT_SECRET"
+PYTICKTICK_V1_TOKEN_VALUE="YOUR_TOKEN_UUID"
+PYTICKTICK_V1_TOKEN_EXPIRATION=1111111111
+PYTICKTICK_V2_USERNAME="YOUR_USERNAME"
+PYTICKTICK_V2_PASSWORD="YOUR_PASSWORD"
 ```
 
 If you don't want to create a `.env` file, you can set the same environment variables in your session before running the tests.

--- a/scripts/generate_v1_token.py
+++ b/scripts/generate_v1_token.py
@@ -58,10 +58,10 @@ def main() -> None:
             confirm("Parent directory does not exist. Create?", abort=True)
             file_path.parent.mkdir(parents=True)
         _text = f"""
-        TICKTICK_API_V1_CLIENT_ID="{client_id}"
-        TICKTICK_API_V1_CLIENT_SECRET="{client_secret}"
-        TICKTICK_API_V1_TOKEN_VALUE="{token_value}"
-        TICKTICK_API_V1_TOKEN_EXPIRATION="{token_expiration}"
+        PYTICKTICK_V1_CLIENT_ID="{client_id}"
+        PYTICKTICK_V1_CLIENT_SECRET="{client_secret}"
+        PYTICKTICK_V1_TOKEN_VALUE="{token_value}"
+        PYTICKTICK_V1_TOKEN_EXPIRATION="{token_expiration}"
         """
         file_path.write_text(_text)
         logger.info(f"Token and expiration saved to `{file_path}`")

--- a/src/pyticktick/settings.py
+++ b/src/pyticktick/settings.py
@@ -123,13 +123,13 @@ class Settings(BaseSettings):  # noqa: DOC601, DOC603
 
     ???+ example "Load settings from environment variables"
         ```bash title=".bashrc"
-        export TICKTICK_API_V1_CLIENT_ID="client_id"
-        export TICKTICK_API_V1_CLIENT_SECRET="client_secret"
-        export TICKTICK_API_V1_TOKEN_VALUE="fa371b10-8b95-442b-b4a5-11a9959d3590"
-        export TICKTICK_API_V1_TOKEN_EXPIRATION="1701701789"
-        export TICKTICK_API_V2_USERNAME="username"
-        export TICKTICK_API_V2_PASSWORD="password"
-        export TICKTICK_API_OVERRIDE_FORBID_EXTRA="True"
+        export PYTICKTICK_V1_CLIENT_ID="client_id"
+        export PYTICKTICK_V1_CLIENT_SECRET="client_secret"
+        export PYTICKTICK_V1_TOKEN_VALUE="fa371b10-8b95-442b-b4a5-11a9959d3590"
+        export PYTICKTICK_V1_TOKEN_EXPIRATION="1701701789"
+        export PYTICKTICK_V2_USERNAME="username"
+        export PYTICKTICK_V2_PASSWORD="password"
+        export PYTICKTICK_OVERRIDE_FORBID_EXTRA="True"
         ```
 
         ```python
@@ -140,13 +140,13 @@ class Settings(BaseSettings):  # noqa: DOC601, DOC603
 
     ???+ example "Load settings from a secret file"
         ```bash title=".env"
-        TICKTICK_API_V1_CLIENT_ID="client_id"
-        TICKTICK_API_V1_CLIENT_SECRET="client_secret"
-        TICKTICK_API_V1_TOKEN_VALUE="fa371b10-8b95-442b-b4a5-11a9959d3590"
-        TICKTICK_API_V1_TOKEN_EXPIRATION="1701701789"
-        TICKTICK_API_V2_USERNAME="username"
-        TICKTICK_API_V2_PASSWORD="password"
-        TICKTICK_API_OVERRIDE_FORBID_EXTRA="True"
+        PYTICKTICK_V1_CLIENT_ID="client_id"
+        PYTICKTICK_V1_CLIENT_SECRET="client_secret"
+        PYTICKTICK_V1_TOKEN_VALUE="fa371b10-8b95-442b-b4a5-11a9959d3590"
+        PYTICKTICK_V1_TOKEN_EXPIRATION="1701701789"
+        PYTICKTICK_V2_USERNAME="username"
+        PYTICKTICK_V2_PASSWORD="password"
+        PYTICKTICK_OVERRIDE_FORBID_EXTRA="True"
         ```
 
         ```python
@@ -175,7 +175,7 @@ class Settings(BaseSettings):  # noqa: DOC601, DOC603
     # BaseSettings: https://github.com/mkdocstrings/griffe-pydantic/issues/27
 
     model_config = SettingsConfigDict(
-        env_prefix="ticktick_api_",
+        env_prefix="pyticktick_",
         env_nested_delimiter="_",
         extra="forbid",
     )

--- a/tests/unit/test_settings.py
+++ b/tests/unit/test_settings.py
@@ -107,18 +107,18 @@ def test_v1_settings_initialize(
     test_v1_token_expiration_days,
 ):
     if from_env:
-        monkeypatch.setenv("TICKTICK_API_V1_CLIENT_ID", test_v1_client_id)
-        monkeypatch.setenv("TICKTICK_API_V1_CLIENT_SECRET", test_v1_client_secret)
-        monkeypatch.setenv("TICKTICK_API_V1_TOKEN_VALUE", test_v1_token_value)
+        monkeypatch.setenv("PYTICKTICK_V1_CLIENT_ID", test_v1_client_id)
+        monkeypatch.setenv("PYTICKTICK_V1_CLIENT_SECRET", test_v1_client_secret)
+        monkeypatch.setenv("PYTICKTICK_V1_TOKEN_VALUE", test_v1_token_value)
         monkeypatch.setenv(
-            "TICKTICK_API_V1_TOKEN_EXPIRATION",
+            "PYTICKTICK_V1_TOKEN_EXPIRATION",
             str(test_v1_token_expiration_days(30)),
         )
         if test_base_url is not None:
-            monkeypatch.setenv("TICKTICK_API_V1_BASE_URL", test_base_url)
+            monkeypatch.setenv("PYTICKTICK_V1_BASE_URL", test_base_url)
         if test_oauth_redirect_url is not None:
             monkeypatch.setenv(
-                "TICKTICK_API_V1_OAUTH_REDIRECT_URL",
+                "PYTICKTICK_V1_OAUTH_REDIRECT_URL",
                 test_oauth_redirect_url,
             )
         settings = Settings()
@@ -156,11 +156,11 @@ def test_v2_settings_initialize(
     test_base_url,
 ):
     if from_env:
-        monkeypatch.setenv("TICKTICK_API_V2_USERNAME", test_v2_username)
-        monkeypatch.setenv("TICKTICK_API_V2_PASSWORD", test_v2_password)
-        monkeypatch.setenv("TICKTICK_API_V2_TOKEN", test_v2_token)
+        monkeypatch.setenv("PYTICKTICK_V2_USERNAME", test_v2_username)
+        monkeypatch.setenv("PYTICKTICK_V2_PASSWORD", test_v2_password)
+        monkeypatch.setenv("PYTICKTICK_V2_TOKEN", test_v2_token)
         if test_base_url is not None:
-            monkeypatch.setenv("TICKTICK_API_V2_BASE_URL", test_base_url)
+            monkeypatch.setenv("PYTICKTICK_V2_BASE_URL", test_base_url)
         settings = Settings()
 
     else:
@@ -260,12 +260,12 @@ def test_other_settings_initialize(
     test_forbid_extra,
 ):
     if from_env:
-        monkeypatch.setenv("TICKTICK_API_V2_USERNAME", test_v2_username)
-        monkeypatch.setenv("TICKTICK_API_V2_PASSWORD", test_v2_password)
-        monkeypatch.setenv("TICKTICK_API_V2_TOKEN", test_v2_token)
+        monkeypatch.setenv("PYTICKTICK_V2_USERNAME", test_v2_username)
+        monkeypatch.setenv("PYTICKTICK_V2_PASSWORD", test_v2_password)
+        monkeypatch.setenv("PYTICKTICK_V2_TOKEN", test_v2_token)
         if test_forbid_extra is not None:
             monkeypatch.setenv(
-                "TICKTICK_API_OVERRIDE_FORBID_EXTRA",
+                "PYTICKTICK_OVERRIDE_FORBID_EXTRA",
                 str(test_forbid_extra),
             )
         settings = Settings()


### PR DESCRIPTION
This PR just renames `TICKTICK_API_...` to `PYTICKTICK_...` when configuring settings via env vars. This better describes what these env vars are used for (this library) and not for all TickTick clients.

Closes https://github.com/sebpretzer/pyticktick/issues/27