### PR TITLE
Move `HTTPUrl` and `Color` out to be generic pydantic types

### DIFF
--- a/docs/reference/models/pydantic.md
+++ b/docs/reference/models/pydantic.md
@@ -1,0 +1,3 @@
+# Pydantic Types
+
+::: pyticktick.models.pydantic

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -85,6 +85,7 @@ nav:
               - Models: reference/models/v2/models.md
               - Types: reference/models/v2/types.md
               - Class Diagrams: reference/models/v2/class_diagrams.md
+          - Pydantic: reference/models/pydantic.md
       - Retry: reference/retry.md
       - Pydantic: reference/pydantic.md
       - Logger: reference/logger.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -160,5 +160,8 @@ extra_checks = false
 [tool.coverage.run]
 relative_files = true
 
+[tool.coverage.report]
+exclude_also = ["if TYPE_CHECKING:"]
+
 [tool.typos.default]
 extend-ignore-words-re = ["ba", "ser_*", "extenal_*", "Fo"]

--- a/src/pyticktick/models/__init__.py
+++ b/src/pyticktick/models/__init__.py
@@ -1,0 +1,3 @@
+from pyticktick.models.pydantic import Color, HttpUrl
+
+__all__ = ["Color", "HttpUrl"]

--- a/src/pyticktick/models/pydantic.py
+++ b/src/pyticktick/models/pydantic.py
@@ -1,0 +1,89 @@
+"""Generic custom pydantic types, not specific to any API version."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from pydantic import HttpUrl as PydanticHttpUrl
+from pydantic_core import CoreSchema, core_schema
+from pydantic_extra_types.color import Color as PydanticColor
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+
+class Color(PydanticColor):
+    """Represents a color in pydantic-based TickTick models."""
+
+    @classmethod
+    def __get_pydantic_core_schema__(  # noqa: DOC101, DOC103, DOC203
+        cls,
+        source: type[Any],
+        handler: Callable[[Any], CoreSchema],
+    ) -> core_schema.CoreSchema:
+        """Change the serialization logic of the color field to always be a string.
+
+        This method mirrors the logic of the standard [`__get_pydantic_core_schema__` method](https://github.com/pydantic/pydantic-extra-types/blob/1da2a1caeb7502e40037e2e3e2961726c2c5c002/pydantic_extra_types/color.py#L213-L219)
+        in [`pydantic_extra_types.color.Color`](https://docs.pydantic.dev/latest/api/pydantic_extra_types_color/),
+        but changes the `when_used` parameter to be `"always"` instead of the default of
+        `"json-unless-none"`.
+        """  # noqa: DOC201
+        return core_schema.with_info_plain_validator_function(
+            cls._validate,
+            serialization=core_schema.to_string_ser_schema(when_used="always"),
+        )
+
+    def __str__(self) -> str:
+        """Return the color as a hex string.
+
+        TickTick uses the long hex format for colors, so this method allows for easy
+        serialization of the color field into the correct format. Equivalent to calling
+        [`as_hex(format="long")`](https://docs.pydantic.dev/latest/api/pydantic_extra_types_color/#pydantic_extra_types.color.Color.as_hex).
+        It will be lowercase and always have 7 characters (and `#`): `#rrggbb`.
+
+        !!! Example
+            ```python
+            color = Color((0, 255, 255))
+            assert color.as_named() == "cyan"
+            assert str(color) == "#00ffff"
+            ```
+
+        Returns:
+            str: The color as a hex string.
+        """
+        return self.as_hex(format="long")
+
+
+class HttpUrl(PydanticHttpUrl):
+    """Represents an HTTP URL in pydantic-based TickTick models."""
+
+    def join(self, *args: str) -> HttpUrl:
+        """Join the current URL with additional path segments.
+
+        This method is a convenience method to join additional path segments to the
+        current URL. It takes its inspiration from the [`urllib.parse.urljoin`](https://docs.python.org/3/library/urllib.parse.html#urllib.parse.urljoin)
+        and [`pathlib.PurePath.joinpath`](https://docs.python.org/3/library/pathlib.html#pathlib.PurePath.joinpath)
+        methods in Python.
+
+        !!! Example
+            ```python
+            from pyticktick.models.v2 import HttpUrl
+
+            url = HttpUrl("https://example.com")
+            assert url.join("foo") == HttpUrl("https://example.com/foo")
+            assert url.join("foo", "bar") == HttpUrl("https://example.com/foo/bar")
+            ```
+
+        Args:
+            *args (str): The path segments to join with the current URL.
+
+        Returns:
+            HttpUrl: A new URL with the path segments joined to the current URL.
+        """
+        if len(args) == 0:
+            return self
+
+        url = str(self).rstrip("/")
+        for arg in args:
+            url = f"{url.rstrip('/')}/{arg.lstrip('/')}"
+        return self.__class__(url)

--- a/src/pyticktick/models/v1/parameters/oauth.py
+++ b/src/pyticktick/models/v1/parameters/oauth.py
@@ -11,8 +11,7 @@ from urllib.parse import urlencode
 
 from pydantic import BaseModel, ConfigDict, Field, model_serializer
 
-# This is an exception to the rule of not sharing models between versions
-from pyticktick.models.v2.types import HttpUrl
+from pyticktick.models.pydantic import HttpUrl
 
 
 class OAuthAuthorizeURLV1(BaseModel):

--- a/src/pyticktick/models/v1/parameters/project.py
+++ b/src/pyticktick/models/v1/parameters/project.py
@@ -6,7 +6,7 @@ from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, Field
 
-from pyticktick.models.v2.types import Color
+from pyticktick.models.pydantic import Color
 
 
 class CreateProjectV1(BaseModel):

--- a/src/pyticktick/models/v2/__init__.py
+++ b/src/pyticktick/models/v2/__init__.py
@@ -42,9 +42,7 @@ from pyticktick.models.v2.responses.user import (
     UserStatusV2,
 )
 from pyticktick.models.v2.types import (
-    Color,
     ETag,
-    HttpUrl,
     ICalTrigger,
     Kind,
     ObjectId,
@@ -63,7 +61,6 @@ __all__ = [
     "BatchTagRespV2",
     "BatchTaskParentRespV2",
     "ClosedRespV2",
-    "Color",
     "CreateItemV2",
     "CreateProjectGroupV2",
     "CreateProjectV2",
@@ -75,7 +72,6 @@ __all__ = [
     "ETag",
     "GetBatchV2",
     "GetClosedV2",
-    "HttpUrl",
     "ICalTrigger",
     "Kind",
     "ObjectId",

--- a/src/pyticktick/models/v2/models.py
+++ b/src/pyticktick/models/v2/models.py
@@ -12,8 +12,8 @@ from typing import Any, Literal, Union
 
 from pydantic import BaseModel, ConfigDict, Field
 
+from pyticktick.models.pydantic import Color
 from pyticktick.models.v2.types import (
-    Color,
     ETag,
     ICalTrigger,
     InboxId,

--- a/src/pyticktick/models/v2/parameters/project.py
+++ b/src/pyticktick/models/v2/parameters/project.py
@@ -11,7 +11,8 @@ from typing import Literal, Union
 
 from pydantic import BaseModel, ConfigDict, Field
 
-from pyticktick.models.v2.types import Color, ObjectId
+from pyticktick.models.pydantic import Color
+from pyticktick.models.v2.types import ObjectId
 
 
 class CreateProjectV2(BaseModel):

--- a/src/pyticktick/models/v2/parameters/tag.py
+++ b/src/pyticktick/models/v2/parameters/tag.py
@@ -11,7 +11,8 @@ from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
-from pyticktick.models.v2.types import Color, TagLabel, TagName
+from pyticktick.models.pydantic import Color
+from pyticktick.models.v2.types import TagLabel, TagName
 
 
 class CreateTagV2(BaseModel):

--- a/src/pyticktick/models/v2/types.py
+++ b/src/pyticktick/models/v2/types.py
@@ -1,4 +1,4 @@
-"""Pydantic types for TickTick API models.
+"""Pydantic types for TickTick V2 API models.
 
 This module provides custom types that restrict more general types to the specific
 values used by the TickTick API. These types are used in Pydantic models to ensure that
@@ -21,24 +21,13 @@ from __future__ import annotations
 import re
 from datetime import timedelta
 from textwrap import dedent
-from typing import TYPE_CHECKING, Annotated, Any, Literal, Optional
+from typing import Annotated, Literal, Optional
 
 from bson import ObjectId as BsonObjectId
 from dateutil.rrule import rrulestr
 from icalendar import Alarm, Calendar
-from pydantic import (
-    AfterValidator,
-    BeforeValidator,
-    StringConstraints,
-    conint,
-)
-from pydantic import HttpUrl as PydanticHttpUrl
-from pydantic_core import CoreSchema, core_schema
-from pydantic_extra_types.color import Color as PydanticColor
+from pydantic import AfterValidator, BeforeValidator, StringConstraints, conint
 from pydantic_extra_types.timezone_name import TimeZoneName as PydanticTimeZoneName
-
-if TYPE_CHECKING:
-    from collections.abc import Callable
 
 ETag = Annotated[str, StringConstraints(pattern=r"^[a-z0-9]{8}$")]
 """Pydantic type for a TickTick ETag.
@@ -299,80 +288,3 @@ TickTick time zone names are based on the [IANA Time Zone Database](https://en.w
 For the most part, the type should be aligned with [`pydantic_extra_types.timezone_name.TimeZoneName`](https://docs.pydantic.dev/latest/api/pydantic_extra_types_timezone_name/#pydantic_extra_types.timezone_name.TimeZoneName),
 except that TickTick allows an empty string or `None` to represent no time zone.
 """
-
-
-class Color(PydanticColor):
-    """Represents a color in pydantic-based TickTick models."""
-
-    @classmethod
-    def __get_pydantic_core_schema__(  # noqa: DOC101, DOC103, DOC203
-        cls,
-        source: type[Any],
-        handler: Callable[[Any], CoreSchema],
-    ) -> core_schema.CoreSchema:
-        """Change the serialization logic of the color field to always be a string.
-
-        This method mirrors the logic of the standard [`__get_pydantic_core_schema__` method](https://github.com/pydantic/pydantic-extra-types/blob/1da2a1caeb7502e40037e2e3e2961726c2c5c002/pydantic_extra_types/color.py#L213-L219)
-        in [`pydantic_extra_types.color.Color`](https://docs.pydantic.dev/latest/api/pydantic_extra_types_color/),
-        but changes the `when_used` parameter to be `"always"` instead of the default of
-        `"json-unless-none"`.
-        """  # noqa: DOC201
-        return core_schema.with_info_plain_validator_function(
-            cls._validate,
-            serialization=core_schema.to_string_ser_schema(when_used="always"),
-        )
-
-    def __str__(self) -> str:
-        """Return the color as a hex string.
-
-        TickTick uses the long hex format for colors, so this method allows for easy
-        serialization of the color field into the correct format. Equivalent to calling
-        [`as_hex(format="long")`](https://docs.pydantic.dev/latest/api/pydantic_extra_types_color/#pydantic_extra_types.color.Color.as_hex).
-        It will be lowercase and always have 7 characters (and `#`): `#rrggbb`.
-
-        !!! Example
-            ```python
-            color = Color((0, 255, 255))
-            assert color.as_named() == "cyan"
-            assert str(color) == "#00ffff"
-            ```
-
-        Returns:
-            str: The color as a hex string.
-        """
-        return self.as_hex(format="long")
-
-
-class HttpUrl(PydanticHttpUrl):
-    """Represents an HTTP URL in pydantic-based TickTick models."""
-
-    def join(self, *args: str) -> HttpUrl:
-        """Join the current URL with additional path segments.
-
-        This method is a convenience method to join additional path segments to the
-        current URL. It takes its inspiration from the [`urllib.parse.urljoin`](https://docs.python.org/3/library/urllib.parse.html#urllib.parse.urljoin)
-        and [`pathlib.PurePath.joinpath`](https://docs.python.org/3/library/pathlib.html#pathlib.PurePath.joinpath)
-        methods in Python.
-
-        !!! Example
-            ```python
-            from pyticktick.models.v2 import HttpUrl
-
-            url = HttpUrl("https://example.com")
-            assert url.join("foo") == HttpUrl("https://example.com/foo")
-            assert url.join("foo", "bar") == HttpUrl("https://example.com/foo/bar")
-            ```
-
-        Args:
-            *args (str): The path segments to join with the current URL.
-
-        Returns:
-            HttpUrl: A new URL with the path segments joined to the current URL.
-        """
-        if len(args) == 0:
-            return self
-
-        url = str(self).rstrip("/")
-        for arg in args:
-            url = f"{url.rstrip('/')}/{arg.lstrip('/')}"
-        return self.__class__(url)

--- a/src/pyticktick/settings.py
+++ b/src/pyticktick/settings.py
@@ -30,10 +30,10 @@ from pydantic import (
 )
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
+from pyticktick.models.pydantic import HttpUrl
 from pyticktick.models.v1.parameters.oauth import OAuthAuthorizeURLV1, OAuthTokenURLV1
 from pyticktick.models.v1.responses.oauth import OAuthTokenV1
 from pyticktick.models.v2.responses.user import UserSignOnV2
-from pyticktick.models.v2.types import HttpUrl
 
 
 class TokenV1(BaseModel):  # noqa: DOC601, DOC603

--- a/tests/integration/v2/test_batch.py
+++ b/tests/integration/v2/test_batch.py
@@ -3,7 +3,8 @@ from datetime import datetime
 import pytest
 from pydantic import TypeAdapter
 
-from pyticktick.models.v2 import Color, GetBatchV2, TimeZoneName
+from pyticktick.models.pydantic import Color
+from pyticktick.models.v2 import GetBatchV2, TimeZoneName
 from pyticktick.models.v2.models import (
     ItemV2,
     ProjectGroupV2,

--- a/tests/unit/test_color.py
+++ b/tests/unit/test_color.py
@@ -3,7 +3,7 @@ import json
 import pytest
 from pydantic import BaseModel
 
-from pyticktick.models.v2 import Color
+from pyticktick.models.pydantic import Color
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_http_url.py
+++ b/tests/unit/test_http_url.py
@@ -6,6 +6,7 @@ from pyticktick.models.pydantic import HttpUrl
 @pytest.mark.parametrize(
     ("base", "to_join", "expected"),
     [
+        ("https://example.com", [], "https://example.com"),
         ("https://example.com", ["foo"], "https://example.com/foo"),
         ("https://example.com", ["/foo"], "https://example.com/foo"),
         ("https://example.com", ["foo/"], "https://example.com/foo/"),

--- a/tests/unit/test_http_url.py
+++ b/tests/unit/test_http_url.py
@@ -1,6 +1,6 @@
 import pytest
 
-from pyticktick.models.v2 import HttpUrl
+from pyticktick.models.pydantic import HttpUrl
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/v1/test_parameters.py
+++ b/tests/unit/v1/test_parameters.py
@@ -1,7 +1,7 @@
 from urllib.parse import urlencode
 
+from pyticktick.models.pydantic import HttpUrl
 from pyticktick.models.v1 import OAuthAuthorizeURLV1, OAuthTokenURLV1
-from pyticktick.models.v2.types import HttpUrl
 
 
 def test_settings_create_authorize_url(test_v1_client_id):


### PR DESCRIPTION
Closes: https://github.com/sebpretzer/pyticktick/issues/8

The main work is just migrating the custom `HTTPUrl` and `Color` from `src/pyticktick/models/v2/types.py` to `src/pyticktick/models/pydantic.py`, since these are not specific to either the `V1` or `V2` APIs, they are just general improvements to the base pydantic classes.