### PR TITLE
V1 model naming conventions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,10 +55,10 @@ mkdocs-publish:
 
 generate-model-mermaid-diagrams:
 	uv run pydantic-mermaid \
-	    -m pyticktick/models/v1/__init__.py \
+	    -m src/pyticktick/models/v1/__init__.py \
 		-o docs/reference/models/v1/class_diagrams.md
 	uv run pydantic-mermaid \
-	    -m pyticktick/models/v2/__init__.py \
+	    -m src/pyticktick/models/v2/__init__.py \
 		-o docs/reference/models/v2/class_diagrams.md
 
 	perl -i -0pe 's/classDiagram\n\n    class/classDiagram\n    direction LR\n    class/g' docs/reference/models/v1/class_diagrams.md

--- a/docs/explanations/code_conventions.md
+++ b/docs/explanations/code_conventions.md
@@ -56,7 +56,7 @@ Parameter models attempt to follow the naming convention of request method, foll
 
 Response models attempt to follow the naming convention of endpoint name / TickTick object type, followed by "resp", followed by API version. Here are some examples:
 
-- `TaskV1()`
+- `TaskRespV1()`
 - `BatchTagRespV2()`
 - `UserSignOnV2()`
 

--- a/docs/reference/models/v1/class_diagrams.md
+++ b/docs/reference/models/v1/class_diagrams.md
@@ -1,35 +1,29 @@
 ```mermaid
 classDiagram
     direction LR
-    class ProjectV1 {
-        id: str
-        name: str
-        color: str | None = None
-        sort_order: int
-        closed: bool | None = None
-        group_id: str | None = None
-        view_mode: Literal['list', 'kanban', 'timeline'] | None = None
-        permission: Literal['read', 'write', 'comment'] | None = None
-        kind: Literal['TASK', 'NOTE'] | None = None
+    class OAuthTokenV1 {
+        access_token: UUID
+        expires_in: int
+        token_type: Literal['bearer'] = 'bearer'
+        scope: Literal['tasks:read tasks:write'] = 'tasks:read tasks:write'
     }
 
-    class TaskV1 {
-        id: str
-        project_id: str
-        title: str
-        is_all_day: bool
-        completed_time: str | None = None
-        content: str | None = None
-        desc: str | None = None
-        due_date: str | None = None
-        items: list[ItemV1] | None = None
-        priority: Literal[0, 1, 3, 5]
-        reminders: list[str] | None = None
-        repeat_flag: str | None = None
-        sort_order: int
-        start_date: str | None = None
-        status: bool
-        time_zone: str
+    class ProjectRespV1 {
+        root: ProjectV1
+    }
+
+    class OAuthAuthorizeURLV1 {
+        client_id: str
+        scope: Literal['tasks:read tasks:write'] = 'tasks:read tasks:write'
+        state: Any = None
+        response_type: Literal['code'] = 'code'
+        base_url: HttpUrl = https://ticktick.com/oauth/authorize
+    }
+
+    class ProjectDataRespV1 {
+        project: ProjectV1
+        tasks: list[TaskRespV1]
+        columns: list[ColumnV1]
     }
 
     class UpdateTaskV1 {
@@ -49,11 +43,42 @@ classDiagram
         items: list[UpdateItemV1] | None = None
     }
 
+    class TaskRespV1 {
+        id: str
+        project_id: str
+        title: str
+        is_all_day: bool
+        completed_time: str | None = None
+        content: str | None = None
+        desc: str | None = None
+        due_date: str | None = None
+        items: list[ItemV1] | None = None
+        priority: Literal[0, 1, 3, 5]
+        reminders: list[str] | None = None
+        repeat_flag: str | None = None
+        sort_order: int
+        start_date: str | None = None
+        status: bool
+        time_zone: str
+    }
+
     class CreateProjectV1 {
         name: str
         color: Color | None = None
         sort_order: int | None = None
         view_mode: Literal['list', 'kanban', 'timeline'] | None = None
+        kind: Literal['TASK', 'NOTE'] | None = None
+    }
+
+    class ProjectV1 {
+        id: str
+        name: str
+        color: str | None = None
+        sort_order: int
+        closed: bool | None = None
+        group_id: str | None = None
+        view_mode: Literal['list', 'kanban', 'timeline'] | None = None
+        permission: Literal['read', 'write', 'comment'] | None = None
         kind: Literal['TASK', 'NOTE'] | None = None
     }
 
@@ -74,12 +99,8 @@ classDiagram
         items: list[CreateItemV1] | None = None
     }
 
-    class OAuthAuthorizeURLV1 {
-        client_id: str
-        scope: Literal['tasks:read tasks:write'] = 'tasks:read tasks:write'
-        state: Any = None
-        response_type: Literal['code'] = 'code'
-        base_url: HttpUrl = 'https://ticktick.com/oauth/authorize'
+    class ProjectsRespV1 {
+        root: list[ProjectV1]
     }
 
     class UpdateProjectV1 {
@@ -90,27 +111,14 @@ classDiagram
         kind: Literal['TASK', 'NOTE'] | None = None
     }
 
-    class ProjectDataV1 {
-        project: ProjectV1
-        tasks: list[TaskV1]
-        columns: list[ColumnV1]
-    }
-
-    class OAuthTokenV1 {
-        access_token: UUID
-        expires_in: int
-        token_type: Literal['bearer'] = 'bearer'
-        scope: Literal['tasks:read tasks:write'] = 'tasks:read tasks:write'
-    }
-
     class OAuthTokenURLV1 {
         client_id: str
         client_secret: str
         code: str
-        oauth_redirect_url: HttpUrl = 'http://127.0.0.1:8080/'
+        oauth_redirect_url: HttpUrl = http://127.0.0.1:8080/
         scope: Literal['tasks:read tasks:write'] = 'tasks:read tasks:write'
         grant_type: Literal['authorization_code'] = 'authorization_code'
-        base_url: HttpUrl = 'https://ticktick.com/oauth/token'
+        base_url: HttpUrl = https://ticktick.com/oauth/token
     }
 
     OAuthAuthorizeURLV1 ..> HttpUrl
@@ -121,10 +129,12 @@ classDiagram
     CreateTaskV1 ..> CreateItemV1
     UpdateTaskV1 ..> UpdateItemV1
     OAuthTokenV1 ..> UUID
-    ProjectDataV1 ..> ProjectV1
-    ProjectDataV1 ..> ColumnV1
-    ProjectDataV1 ..> TaskV1
-    TaskV1 ..> ItemV1
+    ProjectDataRespV1 ..> TaskRespV1
+    ProjectDataRespV1 ..> ColumnV1
+    ProjectDataRespV1 ..> ProjectV1
+    ProjectRespV1 ..> ProjectV1
+    ProjectsRespV1 ..> ProjectV1
+    TaskRespV1 ..> ItemV1
 
 
 ```

--- a/docs/reference/models/v2/class_diagrams.md
+++ b/docs/reference/models/v2/class_diagrams.md
@@ -1,116 +1,6 @@
 ```mermaid
 classDiagram
     direction LR
-    class DeleteTagV2 {
-        name: str
-    }
-
-    class PostBatchTagV2 {
-        add: list[CreateTagV2] = []
-        update: list[UpdateTagV2] = []
-    }
-
-    class UpdateProjectGroupV2 {
-        name: str
-        id: str
-        list_type: Literal['group'] = 'group'
-    }
-
-    class UserSignOnV2 {
-        inbox_id: str
-        token: str
-        user_id: str
-        username: EmailStr
-        active_team_user: bool
-        ds: bool
-        free_trial: bool
-        freq: str | None = None
-        grace_period: bool | None = None
-        need_subscribe: bool
-        pro: bool
-        pro_end_date: str
-        pro_start_date: str | None = None
-        subscribe_freq: str | None = None
-        subscribe_type: str | None = None
-        team_pro: bool
-        team_user: bool
-        user_code: UUID
-    }
-
-    class CreateTaskV2 {
-        project_id: str | str
-        title: str
-        completed_time: datetime | None = None
-        content: str | None = None
-        desc: str | None = None
-        due_date: datetime | None = None
-        etag: str | None = None
-        id: str | None = None
-        is_all_day: bool | None = None
-        is_floating: bool | None = None
-        items: list[CreateItemV2] | None = None
-        kind: Literal['TEXT', 'NOTE', 'CHECKLIST'] = 'TEXT'
-        modified_time: datetime | None = None
-        reminders: list[CreateTaskReminderV2] | None = None
-        repeat_flag: str | None = None
-        repeat_from: Literal[0, 1, 2] | None = None
-        priority: Literal[0, 1, 3, 5] | None = None
-        progress: int | None = None
-        start_date: datetime | None = None
-        status: Literal[-1, 0, 1, 2] | None = None
-        time_zone: TimeZoneName | None | None = None
-        tags: list[str] = []
-        assignee: int | None = None
-        completed_user_id: int | None = None
-        creator: int | None = None
-        sort_order: int | None = None
-    }
-
-    class BatchRespV2 {
-        id2error: dict[str, str]
-        id2etag: dict[str, str]
-    }
-
-    class GetBatchV2 {
-        inbox_id: str
-        project_groups: list[ProjectGroupV2] | None
-        project_profiles: list[ProjectV2]
-        sync_task_bean: SyncTaskBeanV2
-        tags: list[TagV2]
-        check_point: int
-        checks: None
-        filters: list[dict] | None
-        sync_order_bean: dict
-        sync_order_bean_v3: SyncOrderBeanV3V2
-        sync_task_order_bean: SyncTaskOrderBeanV2
-        remind_changes: list
-    }
-
-    class PostBatchTaskParentV2 {
-        root: list[SetTaskParentV2 | UnSetTaskParentV2]
-    }
-
-    class UpdateProjectV2 {
-        id: str
-        name: str
-        color: Color | None = None
-        group_id: str | None = None
-        kind: Literal['TASK', 'NOTE'] | None = None
-        view_mode: Literal['list', 'kanban', 'timeline'] | None = None
-        sort_order: int | None = None
-    }
-
-    class UnSetTaskParentV2 {
-        old_parent_id: str
-        project_id: str
-        task_id: str
-    }
-
-    class CreateTaskReminderV2 {
-        id: str | None = None
-        trigger: str
-    }
-
     class CreateProjectV2 {
         name: str
         color: Color | None = None
@@ -121,77 +11,18 @@ classDiagram
         sort_order: int | None = None
     }
 
-    class PostBatchProjectV2 {
-        add: list[CreateProjectV2] = []
-        delete: list[str] = []
-        update: list[UpdateProjectV2] = []
-    }
-
-    class UserStatisticsV2 {
-        score: int
-        level: int
-        yesterday_completed: int
-        today_completed: int
-        total_completed: int
-        score_by_day: ScoreByDayV2
-        task_by_day: TaskByDayV2
-        task_by_week: TaskByWeekV2
-        task_by_month: TaskByMonthV2
-        today_pomo_count: int
-        yesterday_pomo_count: int
-        total_pomo_count: int
-        today_pomo_duration: int
-        yesterday_pomo_duration: int
-        total_pomo_duration: int
-        pomo_goal: int
-        pomo_duration_goal: int
-        pomo_by_day: dict
-        pomo_by_week: dict
-        pomo_by_month: dict
-    }
-
     class ClosedRespV2 {
         root: list[TaskV2]
     }
 
-    class BatchTaskParentRespV2 {
-        id2error: dict[str, str]
-        id2etag: dict[str, BatchTaskParentRespValueV2]
-    }
-
-    class CreateItemV2 {
-        completed_time: datetime | None = None
+    class CreateProjectGroupV2 {
+        name: str
         id: str | None = None
-        is_all_day: bool | None = None
-        start_date: str | None = None
-        status: Literal[-1, 0, 1, 2] | None = None
-        time_zone: TimeZoneName | None | None = None
-        title: str | None = None
-        sort_order: int | None = None
+        list_type: Literal['group'] = 'group'
     }
 
-    class UpdateTagV2 {
-        label: str
-        color: Color | None = None
-        name: str | None = None
-        parent: str | None = None
-        raw_name: str
-        sort_type: Literal['project', 'title'] = 'project'
-        sort_order: int | None = None
-    }
-
-    class CreateTagV2 {
-        label: str
-        color: Color | None = None
-        name: str | None = None
-        parent: str | None = None
-        sort_type: Literal['project', 'title'] = 'project'
-        sort_order: int | None = None
-    }
-
-    class DeleteTaskV2 {
-        project_id: str | str
-        task_id: str
+    class DeleteTagV2 {
+        name: str
     }
 
     class UserProfileV2 {
@@ -222,29 +53,26 @@ classDiagram
         display_name: str
     }
 
-    class PostBatchTaskV2 {
-        add: list[CreateTaskV2] = []
-        delete: list[DeleteTaskV2] = []
-        update: list[UpdateTaskV2] = []
-        add_attachments: list = []
-        update_attachments: list = []
-    }
-
-    class RenameTagV2 {
-        name: str
-        new_name: str
-    }
-
-    class PostBatchProjectGroupV2 {
-        add: list[CreateProjectGroupV2] = []
-        delete: list[str] = []
-        update: list[UpdateProjectGroupV2] = []
+    class UpdateItemV2 {
+        id: str
+        completed_time: datetime | None = None
+        is_all_day: bool | None = None
+        start_date: str | None = None
+        status: Literal[-1, 0, 1, 2] | None = None
+        time_zone: TimeZoneName | None | None = None
+        title: str | None = None
+        sort_order: int | None = None
     }
 
     class GetClosedV2 {
-        from_: datetime = None
-        to: datetime = None
+        from_: datetime | None = None
+        to: datetime | None = None
         status: Literal['Completed', 'Abandoned']
+    }
+
+    class CreateTaskReminderV2 {
+        id: str | None = None
+        trigger: str
     }
 
     class UpdateTaskV2 {
@@ -276,9 +104,160 @@ classDiagram
         sort_order: int | None = None
     }
 
+    class GetBatchV2 {
+        inbox_id: str
+        project_groups: list[ProjectGroupV2] | None
+        project_profiles: list[ProjectV2]
+        sync_task_bean: SyncTaskBeanV2
+        tags: list[TagV2]
+        check_point: int
+        checks: None
+        filters: list[dict[str, Any]] | None
+        sync_order_bean: dict[str, Any]
+        sync_order_bean_v3: SyncOrderBeanV3V2
+        sync_task_order_bean: SyncTaskOrderBeanV2
+        remind_changes: list[Any]
+    }
+
+    class UpdateProjectGroupV2 {
+        name: str
+        id: str
+        list_type: Literal['group'] = 'group'
+    }
+
+    class RenameTagV2 {
+        name: str
+        new_name: str
+    }
+
+    class UserSignOnV2 {
+        inbox_id: str
+        token: str
+        user_id: str
+        username: EmailStr
+        active_team_user: bool
+        ds: bool
+        free_trial: bool
+        freq: str | None = None
+        grace_period: bool | None = None
+        need_subscribe: bool
+        pro: bool
+        pro_end_date: str
+        pro_start_date: str | None = None
+        subscribe_freq: str | None = None
+        subscribe_type: str | None = None
+        team_pro: bool
+        team_user: bool
+        user_code: UUID
+    }
+
+    class UserStatisticsV2 {
+        score: int
+        level: int
+        yesterday_completed: int
+        today_completed: int
+        total_completed: int
+        score_by_day: ScoreByDayV2
+        task_by_day: TaskByDayV2
+        task_by_week: TaskByWeekV2
+        task_by_month: TaskByMonthV2
+        today_pomo_count: int
+        yesterday_pomo_count: int
+        total_pomo_count: int
+        today_pomo_duration: int
+        yesterday_pomo_duration: int
+        total_pomo_duration: int
+        pomo_goal: int
+        pomo_duration_goal: int
+        pomo_by_day: dict[str, Any]
+        pomo_by_week: dict[str, Any]
+        pomo_by_month: dict[str, Any]
+    }
+
+    class CreateTaskV2 {
+        project_id: str | str
+        title: str
+        completed_time: datetime | None = None
+        content: str | None = None
+        desc: str | None = None
+        due_date: datetime | None = None
+        etag: str | None = None
+        id: str | None = None
+        is_all_day: bool | None = None
+        is_floating: bool | None = None
+        items: list[CreateItemV2] | None = None
+        kind: Literal['TEXT', 'NOTE', 'CHECKLIST'] = 'TEXT'
+        modified_time: datetime | None = None
+        reminders: list[CreateTaskReminderV2] | None = None
+        repeat_flag: str | None = None
+        repeat_from: Literal[0, 1, 2] | None = None
+        priority: Literal[0, 1, 3, 5] | None = None
+        progress: int | None = None
+        start_date: datetime | None = None
+        status: Literal[-1, 0, 1, 2] | None = None
+        time_zone: TimeZoneName | None | None = None
+        tags: list[str] = []
+        assignee: int | None = None
+        completed_user_id: int | None = None
+        creator: int | None = None
+        sort_order: int | None = None
+    }
+
+    class CreateItemV2 {
+        completed_time: datetime | None = None
+        id: str | None = None
+        is_all_day: bool | None = None
+        start_date: str | None = None
+        status: Literal[-1, 0, 1, 2] | None = None
+        time_zone: TimeZoneName | None | None = None
+        title: str | None = None
+        sort_order: int | None = None
+    }
+
     class UpdateTaskReminderV2 {
         id: str
         trigger: str
+    }
+
+    class PostBatchTaskParentV2 {
+        root: list[SetTaskParentV2 | UnSetTaskParentV2]
+    }
+
+    class PostBatchProjectV2 {
+        add: list[CreateProjectV2] = []
+        delete: list[str] = []
+        update: list[UpdateProjectV2] = []
+    }
+
+    class PostBatchTaskV2 {
+        add: list[CreateTaskV2] = []
+        delete: list[DeleteTaskV2] = []
+        update: list[UpdateTaskV2] = []
+        add_attachments: list[Any] = []
+        update_attachments: list[Any] = []
+    }
+
+    class UnSetTaskParentV2 {
+        old_parent_id: str
+        project_id: str
+        task_id: str
+    }
+
+    class DeleteTaskV2 {
+        project_id: str | str
+        task_id: str
+    }
+
+    class PostBatchProjectGroupV2 {
+        add: list[CreateProjectGroupV2] = []
+        delete: list[str] = []
+        update: list[UpdateProjectGroupV2] = []
+    }
+
+    class SetTaskParentV2 {
+        parent_id: str
+        project_id: str
+        task_id: str
     }
 
     class UserStatusV2 {
@@ -302,32 +281,53 @@ classDiagram
         grace_period: bool | None = None
     }
 
-    class SetTaskParentV2 {
-        parent_id: str
-        project_id: str
-        task_id: str
-    }
-
     class BatchTagRespV2 {
         id2error: dict[str, str]
         id2etag: dict[str, str]
     }
 
-    class CreateProjectGroupV2 {
-        name: str
-        id: str | None = None
-        list_type: Literal['group'] = 'group'
+    class PostBatchTagV2 {
+        add: list[CreateTagV2] = []
+        update: list[UpdateTagV2] = []
     }
 
-    class UpdateItemV2 {
-        id: str
-        completed_time: datetime | None = None
-        is_all_day: bool | None = None
-        start_date: str | None = None
-        status: Literal[-1, 0, 1, 2] | None = None
-        time_zone: TimeZoneName | None | None = None
-        title: str | None = None
+    class CreateTagV2 {
+        label: str
+        color: Color | None = None
+        name: str | None = None
+        parent: str | None = None
+        sort_type: Literal['project', 'title', 'tag'] = 'project'
         sort_order: int | None = None
+    }
+
+    class UpdateTagV2 {
+        label: str
+        color: Color | None = None
+        name: str | None = None
+        parent: str | None = None
+        raw_name: str | None = None
+        sort_type: Literal['project', 'title', 'tag'] = 'project'
+        sort_order: int | None = None
+    }
+
+    class UpdateProjectV2 {
+        id: str
+        name: str
+        color: Color | None = None
+        group_id: Literal['NONE'] | None | str = None
+        kind: Literal['TASK', 'NOTE'] | None = None
+        view_mode: Literal['list', 'kanban', 'timeline'] | None = None
+        sort_order: int | None = None
+    }
+
+    class BatchRespV2 {
+        id2error: dict[str, str]
+        id2etag: dict[str, str]
+    }
+
+    class BatchTaskParentRespV2 {
+        id2error: dict[str, str]
+        id2etag: dict[str, BatchTaskParentRespValueV2]
     }
 
     GetClosedV2 ..> datetime
@@ -338,49 +338,48 @@ classDiagram
     PostBatchProjectGroupV2 ..> UpdateProjectGroupV2
     PostBatchProjectGroupV2 ..> CreateProjectGroupV2
     CreateTagV2 ..> Color
-    PostBatchTagV2 ..> UpdateTagV2
     PostBatchTagV2 ..> CreateTagV2
+    PostBatchTagV2 ..> UpdateTagV2
     UpdateTagV2 ..> Color
-    CreateItemV2 ..> datetime
     CreateItemV2 ..> TimeZoneName
-    CreateTaskV2 ..> datetime
+    CreateItemV2 ..> datetime
     CreateTaskV2 ..> CreateItemV2
     CreateTaskV2 ..> TimeZoneName
+    CreateTaskV2 ..> datetime
     CreateTaskV2 ..> CreateTaskReminderV2
-    PostBatchTaskV2 ..> CreateTaskV2
     PostBatchTaskV2 ..> UpdateTaskV2
-    PostBatchTaskV2 ..> list
+    PostBatchTaskV2 ..> Any
     PostBatchTaskV2 ..> DeleteTaskV2
-    UpdateItemV2 ..> datetime
+    PostBatchTaskV2 ..> CreateTaskV2
     UpdateItemV2 ..> TimeZoneName
+    UpdateItemV2 ..> datetime
     UpdateTaskV2 ..> UpdateTaskReminderV2
     UpdateTaskV2 ..> datetime
-    UpdateTaskV2 ..> TimeZoneName
     UpdateTaskV2 ..> UpdateItemV2
-    PostBatchTaskParentV2 ..> UnSetTaskParentV2
+    UpdateTaskV2 ..> TimeZoneName
     PostBatchTaskParentV2 ..> SetTaskParentV2
-    GetBatchV2 ..> ProjectV2
-    GetBatchV2 ..> SyncTaskBeanV2
-    GetBatchV2 ..> TagV2
-    GetBatchV2 ..> dict
-    GetBatchV2 ..> SyncOrderBeanV3V2
+    PostBatchTaskParentV2 ..> UnSetTaskParentV2
     GetBatchV2 ..> SyncTaskOrderBeanV2
-    GetBatchV2 ..> list
+    GetBatchV2 ..> TagV2
+    GetBatchV2 ..> ProjectV2
     GetBatchV2 ..> ProjectGroupV2
+    GetBatchV2 ..> Any
+    GetBatchV2 ..> SyncTaskBeanV2
+    GetBatchV2 ..> SyncOrderBeanV3V2
     ClosedRespV2 ..> TaskV2
     BatchTaskParentRespV2 ..> BatchTaskParentRespValueV2
-    UserProfileV2 ..> EmailStr
     UserProfileV2 ..> Any
+    UserProfileV2 ..> EmailStr
     UserProfileV2 ..> UUID
-    UserSignOnV2 ..> EmailStr
     UserSignOnV2 ..> UUID
-    UserStatisticsV2 ..> dict
-    UserStatisticsV2 ..> ScoreByDayV2
-    UserStatisticsV2 ..> TaskByWeekV2
-    UserStatisticsV2 ..> TaskByMonthV2
+    UserSignOnV2 ..> EmailStr
     UserStatisticsV2 ..> TaskByDayV2
-    UserStatusV2 ..> EmailStr
+    UserStatisticsV2 ..> TaskByWeekV2
+    UserStatisticsV2 ..> Any
+    UserStatisticsV2 ..> TaskByMonthV2
+    UserStatisticsV2 ..> ScoreByDayV2
     UserStatusV2 ..> UUID
+    UserStatusV2 ..> EmailStr
 
 
 ```

--- a/src/pyticktick/client.py
+++ b/src/pyticktick/client.py
@@ -19,7 +19,7 @@ from pyticktick.models.v1.responses.project import (
     ProjectRespV1,
     ProjectsRespV1,
 )
-from pyticktick.models.v1.responses.task import TaskV1
+from pyticktick.models.v1.responses.task import TaskRespV1
 from pyticktick.models.v2.parameters.closed import GetClosedV2
 from pyticktick.models.v2.parameters.project import PostBatchProjectV2
 from pyticktick.models.v2.parameters.project_group import PostBatchProjectGroupV2
@@ -485,7 +485,7 @@ class Client(Settings):
         """
         self._delete_api_v1(f"/project/{project_id}")
 
-    def get_task_v1(self, project_id: str, task_id: str) -> TaskV1:
+    def get_task_v1(self, project_id: str, task_id: str) -> TaskRespV1:
         """Get a single task from the V1 API.
 
         This method calls the [`GET /project/{project_id}/task/{task_id}`](https://developer.ticktick.com/docs/index.html#/openapi?id=get-task-by-project-id-and-task-id)
@@ -533,18 +533,18 @@ class Client(Settings):
             task_id (str): Identifier of the task to retrieve.
 
         Returns:
-            TaskV1: The task object retrieved from the API.
+            TaskRespV1: The task object retrieved from the API.
         """
         resp = self._get_api_v1(f"/project/{project_id}/task/{task_id}")
-        return TaskV1.model_validate(resp)
+        return TaskRespV1.model_validate(resp)
 
-    def create_task_v1(self, data: Union[CreateTaskV1, dict[str, Any]]) -> TaskV1:
+    def create_task_v1(self, data: Union[CreateTaskV1, dict[str, Any]]) -> TaskRespV1:
         """Create a task in the V1 API.
 
         This method creates a new task in the TickTick application using the [`POST /task`](https://developer.ticktick.com/docs/index.html#/openapi?id=create-task)
         V1 endpoint. The `data` parameter can be a `CreateTaskV1` model or a dictionary
         that matches the same structure. The method returns the created task as a
-        `TaskV1` model.
+        `TaskRespV1` model.
 
         ??? example "Example"
             ```python hl_lines="5"
@@ -592,25 +592,25 @@ class Client(Settings):
             data (Union[CreateTaskV1, dict[str, Any]]): Data to create the task.
 
         Returns:
-            TaskV1: Created task object.
+            TaskRespV1: Created task object.
         """
         if isinstance(data, dict):
             data = CreateTaskV1.model_validate(data)
         resp = self._post_api_v1("/task", self._model_dump(data))
-        return TaskV1.model_validate(resp)
+        return TaskRespV1.model_validate(resp)
 
     def update_task_v1(
         self,
         task_id: str,
         data: Union[UpdateTaskV1, dict[str, Any]],
-    ) -> TaskV1:
+    ) -> TaskRespV1:
         """Update a task in the V1 API.
 
         This method updates an existing task in the TickTick application using the
         [`POST /task/{task_id}`](https://developer.ticktick.com/docs/index.html#/openapi?id=update-task)
         V1 endpoint. The `data` parameter can be an `UpdateTaskV1` model or a dictionary
         that matches the same structure. The method returns the updated task as a
-        `TaskV1` model.
+        `TaskRespV1` model.
 
         ??? example "Example"
             ```python hl_lines="5"
@@ -661,12 +661,12 @@ class Client(Settings):
             data (Union[UpdateTaskV1, dict[str, Any]]): Data to update the task.
 
         Returns:
-            TaskV1: Updated task.
+            TaskRespV1: Updated task.
         """
         if isinstance(data, dict):
             data = UpdateTaskV1.model_validate(data)
         resp = self._post_api_v1(f"/task/{task_id}", self._model_dump(data))
-        return TaskV1.model_validate(resp)
+        return TaskRespV1.model_validate(resp)
 
     def complete_task_v1(self, project_id: str, task_id: str) -> None:
         """Complete a task in the V1 API.

--- a/src/pyticktick/models/v1/__init__.py
+++ b/src/pyticktick/models/v1/__init__.py
@@ -2,7 +2,12 @@ from pyticktick.models.v1.parameters.oauth import OAuthAuthorizeURLV1, OAuthToke
 from pyticktick.models.v1.parameters.project import CreateProjectV1, UpdateProjectV1
 from pyticktick.models.v1.parameters.task import CreateTaskV1, UpdateTaskV1
 from pyticktick.models.v1.responses.oauth import OAuthTokenV1
-from pyticktick.models.v1.responses.project import ProjectDataV1, ProjectV1
+from pyticktick.models.v1.responses.project import (
+    ProjectDataRespV1,
+    ProjectRespV1,
+    ProjectsRespV1,
+    ProjectV1,
+)
 from pyticktick.models.v1.responses.task import TaskV1
 
 __all__ = [
@@ -11,8 +16,10 @@ __all__ = [
     "OAuthAuthorizeURLV1",
     "OAuthTokenURLV1",
     "OAuthTokenV1",
-    "ProjectDataV1",
+    "ProjectDataRespV1",
+    "ProjectRespV1",
     "ProjectV1",
+    "ProjectsRespV1",
     "TaskV1",
     "UpdateProjectV1",
     "UpdateTaskV1",

--- a/src/pyticktick/models/v1/__init__.py
+++ b/src/pyticktick/models/v1/__init__.py
@@ -8,7 +8,7 @@ from pyticktick.models.v1.responses.project import (
     ProjectsRespV1,
     ProjectV1,
 )
-from pyticktick.models.v1.responses.task import TaskV1
+from pyticktick.models.v1.responses.task import TaskRespV1
 
 __all__ = [
     "CreateProjectV1",
@@ -20,7 +20,7 @@ __all__ = [
     "ProjectRespV1",
     "ProjectV1",
     "ProjectsRespV1",
-    "TaskV1",
+    "TaskRespV1",
     "UpdateProjectV1",
     "UpdateTaskV1",
 ]

--- a/src/pyticktick/models/v1/responses/project.py
+++ b/src/pyticktick/models/v1/responses/project.py
@@ -6,7 +6,7 @@ from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, Field, RootModel
 
-from pyticktick.models.v1.responses.task import TaskV1
+from pyticktick.models.v1.responses.task import TaskRespV1
 
 
 class ProjectV1(BaseModel):
@@ -108,5 +108,5 @@ class ProjectDataRespV1(BaseModel):
     model_config = ConfigDict(extra="ignore")
 
     project: ProjectV1 = Field(description="Project info")
-    tasks: list[TaskV1] = Field(description="Undone tasks under project")
+    tasks: list[TaskRespV1] = Field(description="Undone tasks under project")
     columns: list[ColumnV1] = Field(description="Columns under project")

--- a/src/pyticktick/models/v1/responses/project.py
+++ b/src/pyticktick/models/v1/responses/project.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Literal
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, RootModel
 
 from pyticktick.models.v1.responses.task import TaskV1
 
@@ -52,9 +52,9 @@ class ColumnV1(BaseModel):
     """Model for a response with column information in the V1 API.
 
     This model is used to represent a column in the V1 API. It is used in the
-    `ProjectDataV1` model to represent columns under a project. It maps directly to the
-    [column](https://developer.ticktick.com/docs#/openapi?id=column) definition in the
-    V1 API docs.
+    `ProjectDataRespV1` model to represent columns under a project. It maps directly to
+    the [column](https://developer.ticktick.com/docs#/openapi?id=column) definition in
+    the V1 API docs.
 
     It is useful for Kanban views of tasks.
     """
@@ -73,7 +73,29 @@ class ColumnV1(BaseModel):
     )
 
 
-class ProjectDataV1(BaseModel):
+class ProjectRespV1(RootModel[ProjectV1]):
+    """Model for a response from the `GET /project/{project_id}` endpoint in the V1 API.
+
+    This model is used to represent a single project in the V1 API. It corresponds to
+    the the [`GET /project/{project_id}`](https://developer.ticktick.com/docs/index.html#/openapi?id=get-project-by-id)
+    V1 endpoint.
+    """
+
+    root: ProjectV1 = Field(description="The project info")
+
+
+class ProjectsRespV1(RootModel[list[ProjectV1]]):
+    """Model for a response from the `GET /project` endpoint in the V1 API.
+
+    This model is used to represent a list of projects in the V1 API. It corresponds to
+    the [`GET /project`](https://developer.ticktick.com/docs/index.html#/openapi?id=get-user-project)
+    V1 endpoint.
+    """
+
+    root: list[ProjectV1] = Field(description="")
+
+
+class ProjectDataRespV1(BaseModel):
     """Model for a response with more detailed project information in the V1 API.
 
     This model is used to represent a project in the V1 API with more detailed

--- a/src/pyticktick/models/v1/responses/task.py
+++ b/src/pyticktick/models/v1/responses/task.py
@@ -11,7 +11,7 @@ class ItemV1(BaseModel):
     """Model for a response with checklist item information in the V1 API.
 
     This model is used to represent a checklist item in the V1 API. It is used in the
-    `TaskV1` model to represent checklist items of a task. It maps directly to the [checklistitem](https://developer.ticktick.com/docs#/openapi?id=checklistitem)
+    `TaskRespV1` model to represent checklist items of a task. It maps directly to the [checklistitem](https://developer.ticktick.com/docs#/openapi?id=checklistitem)
     definition in the V1 API docs.
     """
 
@@ -56,7 +56,7 @@ class ItemV1(BaseModel):
         raise ValueError(msg)
 
 
-class TaskV1(BaseModel):
+class TaskRespV1(BaseModel):
     """Model for a response with task information in the V1 API.
 
     This model is used to represent a task in the V1 API. It is used in a few different

--- a/tests/integration/v1/test_v1_client_project_functions.py
+++ b/tests/integration/v1/test_v1_client_project_functions.py
@@ -1,6 +1,6 @@
 from pyticktick.models.v1 import (
     CreateProjectV1,
-    ProjectDataV1,
+    ProjectDataRespV1,
     ProjectV1,
     UpdateProjectV1,
 )
@@ -63,7 +63,7 @@ def test_get_project_with_data(
 
     project = client.get_project_with_data_v1(project_id)
     assert project is not None
-    assert isinstance(project, ProjectDataV1)
+    assert isinstance(project, ProjectDataRespV1)
     assert isinstance(project.project, ProjectV1)
     assert project.project.id == project_id
     assert project.project.name == test_project_name

--- a/tests/integration/v1/test_v1_client_project_functions.py
+++ b/tests/integration/v1/test_v1_client_project_functions.py
@@ -4,6 +4,7 @@ from pyticktick.models.v1 import (
     ProjectV1,
     UpdateProjectV1,
 )
+from pyticktick.models.v1.responses.project import ProjectRespV1, ProjectsRespV1
 
 
 def test_get_projects(
@@ -14,14 +15,14 @@ def test_get_projects(
     test_project_names = ["test_get_projects_1", "test_get_projects_2"]
     helper_create_or_recreate_projects(test_project_names)
 
-    projects = client.get_projects_v1()
+    resp = client.get_projects_v1()
 
-    assert projects is not None
-    assert isinstance(projects, list)
-    assert all(isinstance(p, ProjectV1) for p in projects)
+    assert resp is not None
+    assert isinstance(resp, ProjectsRespV1)
+    assert all(isinstance(p, ProjectV1) for p in resp.root)
 
     for p in test_project_names:
-        assert p in [p.name for p in projects]
+        assert p in [p.name for p in resp.root]
 
     helper_delete_projects_if_exists(test_project_names)
 
@@ -37,11 +38,11 @@ def test_get_project(
     project_id = resp.get("id")
     assert isinstance(project_id, str)
 
-    project = client.get_project_v1(project_id)
-    assert project is not None
-    assert isinstance(project, ProjectV1)
-    assert project.id == project_id
-    assert project.name == test_project_name
+    resp = client.get_project_v1(project_id)
+    assert resp is not None
+    assert isinstance(resp, ProjectRespV1)
+    assert resp.root.id == project_id
+    assert resp.root.name == test_project_name
 
     helper_delete_projects_if_exists(test_project_name)
 
@@ -83,11 +84,11 @@ def test_create_project(
     test_project_name = "test_create_project"
     helper_delete_projects_if_exists(test_project_name)
 
-    project = client.create_project_v1(CreateProjectV1(name=test_project_name))
+    resp = client.create_project_v1(CreateProjectV1(name=test_project_name))
 
-    assert project is not None
-    assert isinstance(project, ProjectV1)
-    assert project.name == test_project_name
+    assert resp is not None
+    assert isinstance(resp, ProjectRespV1)
+    assert resp.root.name == test_project_name
 
     project_dicts = helper_get_projects()
     assert test_project_name in [p["name"] for p in project_dicts]
@@ -113,8 +114,8 @@ def test_update_project(
         project_id,
         UpdateProjectV1(name=test_project_name_updated),
     )
-    assert project_updated.id == project_id
-    assert project_updated.name == test_project_name_updated
+    assert project_updated.root.id == project_id
+    assert project_updated.root.name == test_project_name_updated
 
     helper_delete_projects_if_exists([test_project_name, test_project_name_updated])
 

--- a/tests/integration/v1/test_v1_client_task_functions.py
+++ b/tests/integration/v1/test_v1_client_task_functions.py
@@ -1,4 +1,4 @@
-from pyticktick.models.v1 import CreateTaskV1, TaskV1, UpdateTaskV1
+from pyticktick.models.v1 import CreateTaskV1, TaskRespV1, UpdateTaskV1
 
 
 def test_get_task(
@@ -21,7 +21,7 @@ def test_get_task(
 
     task = client.get_task_v1(project_id, task_id)
     assert task is not None
-    assert isinstance(task, TaskV1)
+    assert isinstance(task, TaskRespV1)
     assert task.id == task_id
     assert task.project_id == project_id
     assert task.title == test_task_name
@@ -46,7 +46,7 @@ def test_create_task(
         CreateTaskV1(project_id=project_id, title=test_task_name),
     )
     assert task is not None
-    assert isinstance(task, TaskV1)
+    assert isinstance(task, TaskRespV1)
     assert task.project_id == project_id
     assert task.title == test_task_name
 
@@ -86,7 +86,7 @@ def test_update_task(
         UpdateTaskV1(id=task_id, project_id=project_id, title=new_task_name),
     )
     assert task is not None
-    assert isinstance(task, TaskV1)
+    assert isinstance(task, TaskRespV1)
     assert task.id == task_id
     assert task.project_id == project_id
     assert task.title == new_task_name


### PR DESCRIPTION
Closes https://github.com/sebpretzer/pyticktick/issues/35

1. Rename `TaskV1` to `TaskRespV1`
2. Rename `ProjectDataRespV1` to `ProjectDataRespV1`
3. Add `ProjectRespV1` and `ProjectsRespV1`
4. Update class diagrams following the changes