### PR TITLE
Add support for 2FA

### DIFF
--- a/docs/explanations/comparison_of_similar_libraries.md
+++ b/docs/explanations/comparison_of_similar_libraries.md
@@ -74,6 +74,7 @@ The TickTick V2 API is undocumented, so the descriptions below may not be fully 
 | Post Pomodoro Endpoints      | :x:                | :x:                                                           | :x:                                                              | :x:                                                     | :white_check_mark:                                 |
 | Post Habits Endpoints        | :x:                | :x:                                                           | :x:                                                              | :x:                                                     | :white_check_mark:                                 |
 | Post Countdown Endpoints     | :x:                | :x:                                                           | :x:                                                              | :x:                                                     | :x:                                                |
+| 2FA Support                  | :white_check_mark: | :x:                                                           | :x:                                                              | :x:                                                     | :x:                                                |
 
 ??? Question "Why no support for pomodoro, habits, countdown, etc?"
 

--- a/docs/guides/cookbook/settings/authenticate_client_with_2fa.md
+++ b/docs/guides/cookbook/settings/authenticate_client_with_2fa.md
@@ -16,7 +16,7 @@ For our V2 authentication requirements, assume our username is `computer_wiz_02@
     client = Client(
         v2_username="computer_wiz_02@python.org",
         v2_password="password123",
-        v2_totp="5SY29FY0VXU5XBEJCJH3Z4KYNQ7G915S",
+        v2_totp_secret="5SY29FY0VXU5XBEJCJH3Z4KYNQ7G915S",
     )
     ```
 
@@ -34,6 +34,6 @@ For our V2 authentication requirements, assume our username is `computer_wiz_02@
         },
         v2_username="computer_wiz_02@python.org",
         v2_password="password123",
-        v2_totp="5SY29FY0VXU5XBEJCJH3Z4KYNQ7G915S",
+        v2_totp_secret="5SY29FY0VXU5XBEJCJH3Z4KYNQ7G915S",
     )
     ```

--- a/docs/guides/cookbook/settings/authenticate_client_with_2fa.md
+++ b/docs/guides/cookbook/settings/authenticate_client_with_2fa.md
@@ -1,0 +1,39 @@
+# Authenticate Client with 2-Factor Authentication (2FA)
+
+For our V1 authentication requirements, assume our client id is `7p3Hw9YMqnfxaIvKc4` and our client secret is `Qxm^^3h(7ZK994U8M%/g!YFo2VEPs*k!`. Let's also assume we have a token of `a5b2c3a7-9385-47e4-80b8-a445f842e403` and an expires at `1781373801`.
+
+!!! note "2FA Authentication"
+
+    2FA is only used for V2 authentication. If you are using V1, you do not need to worry about 2FA.
+
+For our V2 authentication requirements, assume our username is `computer_wiz_02@python.org` and our password is `password123`. Let's assume that 2FA is enabled for this account, and the 2FA secret is `5SY29FY0VXU5XBEJCJH3Z4KYNQ7G915S`.
+
+=== "V2 with 2FA"
+
+    ```python
+    from pyticktick import Client
+
+    client = Client(
+        v2_username="computer_wiz_02@python.org",
+        v2_password="password123",
+        v2_totp="5SY29FY0VXU5XBEJCJH3Z4KYNQ7G915S",
+    )
+    ```
+
+=== "Both V1 and V2 with 2FA"
+
+    ```python
+    from pyticktick import Client
+
+    client = Client(
+        v1_client_id="7p3Hw9YMqnfxaIvKc4",
+        v1_client_secret="Qxm^^3h(7ZK994U8M%/g!YFo2VEPs*k!",
+        v1_token={
+            "value": "a5b2c3a7-9385-47e4-80b8-a445f842e403",
+            "expiration": 1781373801,
+        },
+        v2_username="computer_wiz_02@python.org",
+        v2_password="password123",
+        v2_totp="5SY29FY0VXU5XBEJCJH3Z4KYNQ7G915S",
+    )
+    ```

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -12,6 +12,7 @@ nav:
               - Authenticate Client via Python: guides/cookbook/settings/authenticate_client_via_python.md
               - Authenticate Client via Env Vars: guides/cookbook/settings/authenticate_client_via_env_vars.md
               - Authenticate Client via Dotenv: guides/cookbook/settings/authenticate_client_via_dotenv.md
+              - Authenticate Client with 2FA: guides/cookbook/settings/authenticate_client_with_2fa.md
           - Tasks:
               - Create a Basic Task: guides/cookbook/tasks/create_a_basic_task.md
               - Update a Basic Task: guides/cookbook/tasks/update_a_basic_task.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
     "pydantic-settings>=2.0.0",
     "pydantic[email]>=2.0.0",
     "pymongo>=4.0.0",
+    "pyotp>=2.9.0",
     "tenacity>=9.0.0",
 ]
 

--- a/src/pyticktick/models/v2/__init__.py
+++ b/src/pyticktick/models/v2/__init__.py
@@ -38,6 +38,7 @@ from pyticktick.models.v2.responses.task_parent import BatchTaskParentRespV2
 from pyticktick.models.v2.responses.user import (
     UserProfileV2,
     UserSignOnV2,
+    UserSignOnWithTOTPV2,
     UserStatisticsV2,
     UserStatusV2,
 )
@@ -99,6 +100,7 @@ __all__ = [
     "UpdateTaskV2",
     "UserProfileV2",
     "UserSignOnV2",
+    "UserSignOnWithTOTPV2",
     "UserStatisticsV2",
     "UserStatusV2",
 ]

--- a/src/pyticktick/models/v2/responses/user.py
+++ b/src/pyticktick/models/v2/responses/user.py
@@ -22,6 +22,23 @@ from pydantic import (
 )
 
 
+class UserSignOnWithTOTPV2(BaseModel):
+    """Model for the response of a sign-on request via the V2 API with TOTP.
+
+    This model is used when the user has enabled two-factor authentication (2FA) via
+    TOTP (Time-based One-Time Password).
+    """
+
+    auth_id: str = Field(
+        validation_alias="authId",
+        description="The authentication ID used for the sign-on request.",
+    )
+    expire_time: int = Field(
+        validation_alias="expireTime",
+        description="The expiration time of the authentication ID in seconds since the epoch.",
+    )
+
+
 class UserSignOnV2(BaseModel):
     """Model for the response of a sign-on request via the V2 API.
 

--- a/src/pyticktick/settings.py
+++ b/src/pyticktick/settings.py
@@ -120,6 +120,17 @@ class Settings(BaseSettings):  # noqa: DOC601, DOC603
         )
         ```
 
+    ???+ example "Load only V2 API settings when 2FA is enabled"
+        ```python
+        from pyticktick import Settings
+
+        settings = Settings(
+            v2_username="username",
+            v2_password="password",
+            v2_totp="totp_secret",
+        )
+        ```
+
     This class is a subclass of `pydantic_settings.BaseSettings`, which allows for
     [environment variable and secret file parsing](https://docs.pydantic.dev/latest/concepts/pydantic_settings/).
 
@@ -167,6 +178,8 @@ class Settings(BaseSettings):  # noqa: DOC601, DOC603
             Defaults to `http://127.0.0.1:8080/`.
         v2_username (Optional[EmailStr]): The username for the V2 API.
         v2_password (Optional[SecretStr]): The password for the V2 API.
+        v2_totp (Optional[SecretStr]): The TOTP secret for the V2 API, required for
+            two-factor authentication.
         v2_token (Optional[str]): The cookie token for the V2 API.
         v2_base_url (HttpUrl): The base URL for the V2 API. Defaults to
             `https://api.ticktick.com/api/v2/`.

--- a/tests/integration/test_integration_settings.py
+++ b/tests/integration/test_integration_settings.py
@@ -28,15 +28,39 @@ def test_authenticate_v1(client):
     assert settings.v1_token != client.v1_token
 
 
-def test_initialize_api_v2(client):
+def test_initialize_api_v2_without_totp(client):
     _username = client.v2_username
     _password = client.v2_password.get_secret_value()
+
+    if client.v2_totp is not None:
+        pytest.skip("Client initialized with TOTP, skipping test.")
 
     settings = Settings(v2_username=_username, v2_password=_password)
 
     assert settings.v2_username == _username
     assert isinstance(settings.v2_password, SecretStr)
     assert settings.v2_password.get_secret_value() == _password
+    assert settings.v2_token is not None
+    assert isinstance(settings.v2_token, str)
+
+    assert settings.v2_token != client.v2_token
+
+
+def test_initialize_api_v2_with_totp(client):
+    _username = client.v2_username
+    _password = client.v2_password.get_secret_value()
+    _totp = client.v2_totp.get_secret_value()
+
+    if client.v2_totp is None:
+        pytest.skip("Client initialized without TOTP, skipping test.")
+
+    settings = Settings(v2_username=_username, v2_password=_password, v2_totp=_totp)
+
+    assert settings.v2_username == _username
+    assert isinstance(settings.v2_password, SecretStr)
+    assert settings.v2_password.get_secret_value() == _password
+    assert isinstance(settings.v2_totp, SecretStr)
+    assert settings.v2_totp.get_secret_value() == _totp
     assert settings.v2_token is not None
     assert isinstance(settings.v2_token, str)
 

--- a/tests/integration/test_integration_settings.py
+++ b/tests/integration/test_integration_settings.py
@@ -32,7 +32,7 @@ def test_initialize_api_v2_without_totp(client):
     _username = client.v2_username
     _password = client.v2_password.get_secret_value()
 
-    if client.v2_totp is not None:
+    if client.v2_totp_secret is not None:
         pytest.skip("Client initialized with TOTP, skipping test.")
 
     settings = Settings(v2_username=_username, v2_password=_password)
@@ -49,18 +49,22 @@ def test_initialize_api_v2_without_totp(client):
 def test_initialize_api_v2_with_totp(client):
     _username = client.v2_username
     _password = client.v2_password.get_secret_value()
-    _totp = client.v2_totp.get_secret_value()
+    _totp = client.v2_totp_secret.get_secret_value()
 
-    if client.v2_totp is None:
+    if client.v2_totp_secret is None:
         pytest.skip("Client initialized without TOTP, skipping test.")
 
-    settings = Settings(v2_username=_username, v2_password=_password, v2_totp=_totp)
+    settings = Settings(
+        v2_username=_username,
+        v2_password=_password,
+        v2_totp_secret=_totp,
+    )
 
     assert settings.v2_username == _username
     assert isinstance(settings.v2_password, SecretStr)
     assert settings.v2_password.get_secret_value() == _password
-    assert isinstance(settings.v2_totp, SecretStr)
-    assert settings.v2_totp.get_secret_value() == _totp
+    assert isinstance(settings.v2_totp_secret, SecretStr)
+    assert settings.v2_totp_secret.get_secret_value() == _totp
     assert settings.v2_token is not None
     assert isinstance(settings.v2_token, str)
 

--- a/uv.lock
+++ b/uv.lock
@@ -1121,6 +1121,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pyotp"
+version = "2.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/b2/1d5994ba2acde054a443bd5e2d384175449c7d2b6d1a0614dbca3a63abfc/pyotp-2.9.0.tar.gz", hash = "sha256:346b6642e0dbdde3b4ff5a930b664ca82abfa116356ed48cc42c7d6590d36f63", size = 17763, upload-time = "2023-07-27T23:41:03.295Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c3/c0/c33c8792c3e50193ef55adb95c1c3c2786fe281123291c2dbf0eaab95a6f/pyotp-2.9.0-py3-none-any.whl", hash = "sha256:81c2e5865b8ac55e825b0358e496e1d9387c811e85bb40e71a3b29b288963612", size = 13376, upload-time = "2023-07-27T23:41:01.685Z" },
+]
+
+[[package]]
 name = "pyperclip"
 version = "1.9.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1227,6 +1236,7 @@ dependencies = [
     { name = "pydantic-extra-types" },
     { name = "pydantic-settings" },
     { name = "pymongo" },
+    { name = "pyotp" },
     { name = "tenacity" },
 ]
 
@@ -1265,6 +1275,7 @@ requires-dist = [
     { name = "pydantic-extra-types", specifier = ">=2.2.0" },
     { name = "pydantic-settings", specifier = ">=2.0.0" },
     { name = "pymongo", specifier = ">=4.0.0" },
+    { name = "pyotp", specifier = ">=2.9.0" },
     { name = "tenacity", specifier = ">=9.0.0" },
 ]
 


### PR DESCRIPTION
This PR adds support for [2FA](https://help.ticktick.com/external/articles/7307588296744370176). It should be backwards compatible with existing code.

When 2FA is turned on, `POST https://api.ticktick.com/api/v2/user/signon?wc=true&remember=true` does not return the standard output, but instead returns `{"authId":"123ABC","expireTime":456}`. The `authId` should be captured and used in the headers when hitting: `POST https://api.ticktick.com/api/v2/user/sign/mfa/code/verify`. This will then return the same output as `user/signon`, and the standard sign on process can be carried forward.

This was tested locally with 2FA turned on, but CI will not use 2FA.