### PR TITLE
Fix empty string conversion for `TaskV2`

### DIFF
--- a/src/pyticktick/models/v2/models.py
+++ b/src/pyticktick/models/v2/models.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Any, Literal, Union
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from pyticktick.models.pydantic import Color
 from pyticktick.models.v2.types import (
@@ -381,3 +381,10 @@ class TaskV2(BaseModel):
     img_mode: int | None = Field(default=None, validation_alias="imgMode")
     focus_summaries: list[Any] = Field(default=[], validation_alias="focusSummaries")
     sort_order: int = Field(validation_alias="sortOrder")
+
+    @field_validator("*", mode="before")
+    @classmethod
+    def _empty_str_to_none(cls, v: Any) -> Any:
+        if isinstance(v, str) and len(v) == 0:
+            return None
+        return v

--- a/src/pyticktick/models/v2/parameters/closed.py
+++ b/src/pyticktick/models/v2/parameters/closed.py
@@ -8,9 +8,9 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Literal
+from typing import Any, Literal
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_serializer
 
 
 class GetClosedV2(BaseModel):
@@ -24,12 +24,18 @@ class GetClosedV2(BaseModel):
 
     from_: datetime | None = Field(
         default=None,
-        alias="The latest date to get tasks from",
+        description="The earliest date to get tasks from",
     )
     to: datetime | None = Field(
         default=None,
-        description="The earliest date to get tasks from",
+        description="The latest date to get tasks from",
     )
     status: Literal["Completed", "Abandoned"] = Field(
         description='Whether to get completed or "won\'t do" tasks',
     )
+
+    @field_serializer("from_", "to")
+    def _serialize_dt(self, dt: datetime | None, _info: Any) -> str | None:
+        if dt is None:
+            return None
+        return dt.replace(tzinfo=None).isoformat(sep=" ", timespec="seconds")


### PR DESCRIPTION
Some `TaskV2` responses return empty strings. These should actually be considered `None`, so that downstream casts can ignore them.