### PR TITLE
Silence integration test warnings

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,3 +1,4 @@
+import warnings
 from pathlib import Path
 
 import pytest
@@ -7,6 +8,12 @@ from pyticktick import Client
 
 @pytest.fixture()
 def client() -> Client:
-    if not (env_file_path := Path(__file__).parents[2].joinpath(".env")).exists():
-        return Client()
-    return Client(_env_file=env_file_path)  # pyright: ignore[reportCallIssue] # https://github.com/pydantic/pydantic/issues/3072
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "error",
+            message="`token` will expire in less than 7 days",
+        )
+        if not (env_file_path := Path(__file__).parents[2].joinpath(".env")).exists():
+            return Client()
+        return Client(_env_file=env_file_path)  # pyright: ignore[reportCallIssue]
+        # https://github.com/pydantic/pydantic/issues/3072

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -15,5 +15,4 @@ def client() -> Client:
         )
         if not (env_file_path := Path(__file__).parents[2].joinpath(".env")).exists():
             return Client()
-        return Client(_env_file=env_file_path)  # pyright: ignore[reportCallIssue]
-        # https://github.com/pydantic/pydantic/issues/3072
+        return Client(_env_file=env_file_path)  # pyright: ignore[reportCallIssue] # https://github.com/pydantic/pydantic/issues/3072

--- a/tests/integration/test_integration_settings.py
+++ b/tests/integration/test_integration_settings.py
@@ -46,6 +46,7 @@ def test_initialize_api_v2_without_totp(client):
     assert settings.v2_token != client.v2_token
 
 
+@pytest.mark.filterwarnings("ignore:Cannot signon to v1")
 def test_initialize_api_v2_with_totp(client):
     _username = client.v2_username
     _password = client.v2_password.get_secret_value()


### PR DESCRIPTION
This PR fixes the warnings for integration tests, which in this case is just `test_initialize_api_v2_with_totp`. Other error were do to a soon to expire token. This warning should raise an error, so that the token be refreshed before it fails.