### PR TITLE
Release 0.3.0

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.3.0
+
+- Improve error messages for broken v2 headers; allow overriding headers [#227](https://github.com/sebpretzer/pyticktick/pull/227)
+- Improve error messages for extra fields in models [#223](https://github.com/sebpretzer/pyticktick/pull/223)
+- Add support for Python 3.14 and remove support for Python 3.9; fix broken v2 headers [#201](https://github.com/sebpretzer/pyticktick/pull/201)
+- Add `background` field to `pyticktick.models.v2.ProjectV2` [#200](https://github.com/sebpretzer/pyticktick/pull/200)
+
 ## 0.2.0
 
 - Add missing fields to `pyticktick.models.v2.TaskV2` [#86](https://github.com/sebpretzer/pyticktick/pull/86)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 
 [project]
 name = "pyticktick"
-version = "0.2.0"
+version = "0.3.0"
 description = "The modern library to interact with the TickTick API."
 authors = [{ name = "Seb Pretzer", email = "quick.creek3304@fastmail.com" }]
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -1327,7 +1327,7 @@ wheels = [
 
 [[package]]
 name = "pyticktick"
-version = "0.2.0"
+version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Followed [the guide](https://pyticktick.pretzer.io/guides/development/release_process/).